### PR TITLE
Add Pi system stats and service log viewer

### DIFF
--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -1,5 +1,7 @@
 // DCSDashboard.jsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import SystemStatsCard from "./components/SystemStatsCard";
+import LogViewer from "./components/LogViewer";
 
 /** ======== CONFIG ======== */
 const WS_URL = "ws://192.168.1.125:8765"; // <-- change if your Pi IP changes
@@ -183,6 +185,9 @@ export default function DCSDashboard() {
   const [connOK, setConnOK] = useState(false);
   const [pump, setPump]   = useState(false);
 
+  const [sys, setSys] = useState(null);
+  const [logs, setLogs] = useState([]);
+
   // PVs
   const [level, setLevel] = useState(35);
   const [flow,  setFlow]  = useState(0);
@@ -219,6 +224,9 @@ export default function DCSDashboard() {
           const msg = JSON.parse(ev.data);
           if (msg.pump === "on") setPump(true);
           if (msg.pump === "off") setPump(false);
+          if (msg.type === "metrics") setSys(msg.data);
+          if (msg.type === "log") setLogs(prev => [...prev, msg.line].slice(-200));
+          if (msg.type === "log_init") setLogs(msg.lines.slice(-200));
         } catch {/* ignore */}
       };
 
@@ -363,6 +371,8 @@ export default function DCSDashboard() {
             </span></div>
           </div>
         </div>
+
+        <SystemStatsCard stats={sys} />
       </div>
 
       {/* Main: Process Graphic */}
@@ -380,6 +390,7 @@ export default function DCSDashboard() {
         <PV tag="FT-104" value={flow}  unit="gpm" min={0} max={100} />
         <PV tag="PT-102" value={press} unit="psi" min={0} max={30} />
         <PV tag="TT-103" value={temp}  unit="°C"  min={0} max={100} />
+        <LogViewer lines={logs} onClear={() => setLogs([])} />
       </div>
 
       {/* Bottom: Alarms + ACK (snooze) */}

--- a/desktop-app/src/components/LogViewer.jsx
+++ b/desktop-app/src/components/LogViewer.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef, useState } from "react";
+
+function LogViewer({ lines = [], onClear }) {
+  const [filter, setFilter] = useState("");
+  const [paused, setPaused] = useState(false);
+  const boxRef = useRef(null);
+
+  useEffect(() => {
+    if (!paused && boxRef.current) {
+      boxRef.current.scrollTop = boxRef.current.scrollHeight;
+    }
+  }, [lines, paused]);
+
+  const handleClear = () => {
+    if (onClear) onClear();
+  };
+
+  const filtered = lines.filter((l) =>
+    l.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  return (
+    <div className="bg-[#15181b] border-2 border-[#32373e] rounded p-3 text-xs text-gray-300 font-mono flex flex-col h-64">
+      <div className="flex items-center justify-between mb-2">
+        <div className="uppercase text-gray-400">Logs</div>
+        <div className="flex items-center gap-2">
+          <input
+            className="bg-[#0f1113] border border-[#32373e] rounded px-1 py-0.5 text-xs"
+            placeholder="filter"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+          <button
+            className="border border-[#32373e] rounded px-2 py-0.5"
+            onClick={() => setPaused((p) => !p)}
+          >
+            {paused ? "Resume" : "Pause"}
+          </button>
+          <button
+            className="border border-[#32373e] rounded px-2 py-0.5"
+            onClick={handleClear}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+      <pre ref={boxRef} className="flex-1 overflow-y-auto bg-[#0f1113] p-2 rounded">
+        {filtered.join("\n")}
+      </pre>
+    </div>
+  );
+}
+
+export default LogViewer;

--- a/desktop-app/src/components/SystemStatsCard.jsx
+++ b/desktop-app/src/components/SystemStatsCard.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+function SystemStatsCard({ stats }) {
+  const uptime = (s) => {
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    return `${h}h ${m}m ${sec}s`;
+  };
+
+  const pill = () => {
+    const state = stats?.service?.active || "inactive";
+    const base = "px-2 py-0.5 rounded-full text-xs capitalize";
+    if (state === "running") return `${base} bg-green-600 text-white`;
+    if (state === "failed") return `${base} bg-red-600 text-white`;
+    return `${base} bg-gray-600 text-white`;
+  };
+
+  return (
+    <div className="bg-[#15181b] border-2 border-[#32373e] rounded p-3 text-xs text-gray-300 font-mono">
+      <div className="flex items-center justify-between mb-2">
+        <div className="uppercase text-gray-400">System Stats</div>
+        {stats && <span className={pill()}>{stats.service.active}</span>}
+      </div>
+      {stats ? (
+        <div className="grid grid-cols-2 gap-y-1">
+          <div>CPU</div>
+          <div className="text-right">{stats.cpu_pct.toFixed(1)}%</div>
+          <div>CPU Temp</div>
+          <div className="text-right">
+            {stats.cpu_temp_c !== null ? `${stats.cpu_temp_c.toFixed(1)}°C` : "n/a"}
+          </div>
+          <div>Memory</div>
+          <div className="text-right">{stats.mem_pct.toFixed(1)}%</div>
+          <div>Disk /</div>
+          <div className="text-right">{stats.disk_root_pct.toFixed(1)}%</div>
+          <div>Uptime</div>
+          <div className="text-right">{uptime(stats.uptime_s)}</div>
+        </div>
+      ) : (
+        <div className="text-gray-500">No data</div>
+      )}
+    </div>
+  );
+}
+
+export default SystemStatsCard;

--- a/raspberry-pi/pi_server.py
+++ b/raspberry-pi/pi_server.py
@@ -1,0 +1,132 @@
+import asyncio
+import json
+import subprocess
+import time
+from collections import deque
+
+import psutil
+import websockets
+
+CLIENTS = set()
+LOG_BUFFER = deque(maxlen=100)
+
+
+def read_cpu_temp():
+    try:
+        with open("/sys/class/thermal/thermal_zone0/temp") as f:
+            return float(f.read().strip()) / 1000.0
+    except Exception:
+        return None
+
+
+def service_status():
+    try:
+        out = subprocess.check_output(
+            ["systemctl", "is-active", "tankpi.service"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        out = "inactive"
+    return out or "inactive"
+
+
+def collect_metrics():
+    cpu_pct = psutil.cpu_percent()
+    mem_pct = psutil.virtual_memory().percent
+    disk_root_pct = psutil.disk_usage("/").percent
+    uptime_s = int(time.time() - psutil.boot_time())
+    cpu_temp = read_cpu_temp()
+    return {
+        "cpu_pct": cpu_pct,
+        "cpu_temp_c": cpu_temp,
+        "mem_pct": mem_pct,
+        "disk_root_pct": disk_root_pct,
+        "uptime_s": uptime_s,
+        "service": {"name": "tankpi.service", "active": service_status()},
+    }
+
+
+async def broadcast(msg):
+    if not CLIENTS:
+        return
+    data = json.dumps(msg)
+    to_drop = set()
+    for ws in CLIENTS:
+        try:
+            await ws.send(data)
+        except Exception:
+            to_drop.add(ws)
+    for ws in to_drop:
+        CLIENTS.discard(ws)
+
+
+async def metrics_publisher():
+    while True:
+        await asyncio.sleep(5)
+        await broadcast({"type": "metrics", "data": collect_metrics()})
+
+
+async def temp_publisher():
+    while True:
+        t = read_cpu_temp()
+        if t is not None:
+            await broadcast({"temp": t})
+        await asyncio.sleep(2)
+
+
+async def follow_journal():
+    cmd = ["journalctl", "-u", "tankpi.service", "-f", "-o", "short-iso"]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+    except Exception:
+        return
+    while True:
+        line = await proc.stdout.readline()
+        if not line:
+            break
+        text = line.decode(errors="ignore").rstrip()
+        LOG_BUFFER.append(text)
+        await broadcast({"type": "log", "line": text})
+
+
+def seed_logs():
+    cmd = ["journalctl", "-u", "tankpi.service", "-n", "100", "-o", "short-iso"]
+    try:
+        out = subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL)
+    except Exception:
+        return
+    for line in out.splitlines()[-100:]:
+        LOG_BUFFER.append(line.rstrip())
+
+
+async def handler(ws):
+    CLIENTS.add(ws)
+    try:
+        await ws.send(json.dumps({"type": "log_init", "lines": list(LOG_BUFFER)}))
+        await ws.send(json.dumps({"type": "metrics", "data": collect_metrics()}))
+        async for message in ws:
+            try:
+                data = json.loads(message)
+            except Exception:
+                continue
+            if data.get("command") == "pump":
+                state = "on" if data.get("state") == "on" else "off"
+                await broadcast({"pump": state})
+    finally:
+        CLIENTS.discard(ws)
+
+
+async def main():
+    seed_logs()
+    asyncio.create_task(metrics_publisher())
+    asyncio.create_task(temp_publisher())
+    asyncio.create_task(follow_journal())
+    async with websockets.serve(handler, "0.0.0.0", 8765):
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add asyncio WebSocket server that publishes system metrics and tankpi.service logs
- show live system stats and service log tail on the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m py_compile raspberry-pi/pi_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b50d34a5ec832ba8cd43857efebed2