### PR TITLE
feat: add pump log modal and controls

### DIFF
--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -1,7 +1,8 @@
 // DCSDashboard.jsx
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import SystemStatsCard from "./components/SystemStatsCard";
-import LogViewer from "./components/LogViewer";
+import PumpControls from "./components/PumpControls";
+import PumpLogsModal from "./components/PumpLogsModal";
 
 /** ======== CONFIG ======== */
 const WS_URL = "ws://192.168.1.125:8765"; // <-- change if your Pi IP changes
@@ -96,15 +97,6 @@ const btn = (active, danger = false) => ({
     : "0 0 0 2px rgba(255,255,255,0.04) inset",
 });
 
-const lamp = (on, colorOn, colorOff = "#3a3f45") => ({
-  width: 12,
-  height: 12,
-  borderRadius: 12,
-  background: on ? colorOn : colorOff,
-  boxShadow: on ? `0 0 10px ${colorOn}` : "none",
-  border: "1px solid #000",
-});
-
 /** ======== SIMPLE INSTRUMENT PANEL ======== */
 function PV({ tag, value, unit, min = 0, max = 100, alarmHi, alarmLo }) {
   const pct = Math.max(0, Math.min(100, ((value - min) * 100) / (max - min)));
@@ -178,6 +170,9 @@ export default function DCSDashboard() {
 
   const [sys, setSys] = useState(null);
   const [logs, setLogs] = useState([]);
+  const [showPumpLogs, setShowPumpLogs] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [serviceActive, setServiceActive] = useState('inactive');
 
   // PVs
   const [level, setLevel] = useState(35);
@@ -243,7 +238,12 @@ export default function DCSDashboard() {
 
     wsStats.onmessage = (e) => {
       let msg; try { msg = JSON.parse(e.data); } catch { return; }
-      if (msg.type === "metrics") setSys(msg.data);
+      if (msg.type === "metrics") {
+        setSys(msg.data);
+        if (msg.data && msg.data.service && typeof msg.data.service.active !== 'undefined') {
+          setServiceActive(msg.data.service.active);
+        }
+      }
       if (msg.type === "log") setLogs(prev => [...prev, msg.line].slice(-200));
       if (msg.type === "log_init") setLogs(msg.lines.slice(-200));
     };
@@ -272,6 +272,7 @@ export default function DCSDashboard() {
   /** ----- Pump buttons ----- */
   const handleRun  = () => { unlockAudio(); if (!pump) { sendPump(true);  setPump(true);  } };
   const handleStop = () => { unlockAudio(); if (pump)  { sendPump(false); setPump(false); } };
+  const handleClearLogs = () => setLogs([]);
 
   /** ----- Process simulation ----- */
   useEffect(() => {
@@ -351,19 +352,12 @@ export default function DCSDashboard() {
 
       {/* Left: Controls */}
       <div style={leftPanel}>
-        <div>
-          <div style={sectionTitle}>Pump Controls</div>
-          <div style={{ display: "grid", gap: 10 }}>
-            <button style={btn(pump)} onClick={handleRun} disabled={pump}>
-              <span style={lamp(pump, "#2bd673")} />
-              RUN P-101
-            </button>
-            <button style={btn(false, true)} onClick={handleStop} disabled={!pump}>
-              <span style={lamp(!pump, "#e04f4f")} />
-              STOP P-101
-            </button>
-          </div>
-        </div>
+        <PumpControls
+          pump={pump}
+          onRun={handleRun}
+          onStop={handleStop}
+          onShowLogs={() => setShowPumpLogs(true)}
+        />
 
         <div>
           <div style={sectionTitle}>Connection</div>
@@ -393,7 +387,6 @@ export default function DCSDashboard() {
         <PV tag="FT-104" value={flow}  unit="gpm" min={0} max={100} />
         <PV tag="PT-102" value={press} unit="psi" min={0} max={30} />
         <PV tag="TT-103" value={temp}  unit="°C"  min={0} max={100} />
-        <LogViewer lines={logs} />
       </div>
 
       {/* Bottom: Alarms + ACK (snooze) */}
@@ -426,6 +419,16 @@ export default function DCSDashboard() {
           <div style={{ color: "#7fffb2" }}>NO ACTIVE ALARMS</div>
         )}
       </div>
+
+      <PumpLogsModal
+        isOpen={showPumpLogs}
+        onClose={() => setShowPumpLogs(false)}
+        logs={logs}
+        onClear={handleClearLogs}
+        paused={paused}
+        onPauseToggle={() => setPaused((p) => !p)}
+        serviceActive={serviceActive}
+      />
     </div>
   );
 }

--- a/desktop-app/src/components/LogViewer.jsx
+++ b/desktop-app/src/components/LogViewer.jsx
@@ -1,52 +1,59 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-export default function LogViewer({ lines }) {
+/**
+ * Generic log viewer with optional filtering and controls.
+ *
+ * Props:
+ *  - lines: string[]            Lines of text to display
+ *  - onClear?: () => void       Called when Clear is pressed
+ *  - onPauseToggle?: () => void Called when Pause/Resume is pressed
+ *  - paused?: boolean           When true, auto-scroll is disabled
+ *  - header?: string            Optional title to show in the header
+ */
+export default function LogViewer({
+  lines,
+  onClear,
+  onPauseToggle,
+  paused = false,
+  header,
+}) {
   const [filter, setFilter] = useState('');
-  const [paused, setPaused] = useState(false);
-  const [display, setDisplay] = useState([]);
-  const [clearedAt, setClearedAt] = useState(0);
   const bottomRef = useRef(null);
 
-  useEffect(() => {
-    if (!paused) {
-      setDisplay(lines.slice(clearedAt));
-    }
-  }, [lines, paused, clearedAt]);
-
+  // auto-scroll to bottom when new lines arrive and not paused
   useEffect(() => {
     if (!paused) {
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [display, paused]);
+  }, [lines, paused, filter]);
 
-  const onClear = () => {
-    setClearedAt(lines.length);
-    setDisplay([]);
-  };
-
-  const filtered = display.filter((l) =>
+  const filtered = lines.filter((l) =>
     l.toLowerCase().includes(filter.toLowerCase())
   );
 
   return (
     <div className="bg-gray-900 text-teal-300 p-4 rounded shadow font-mono text-xs flex flex-col h-64">
       <div className="flex items-center mb-2 space-x-2">
-        <span className="font-bold">LOGS</span>
+        {header && <span className="font-bold">{header}</span>}
         <input
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           className="flex-1 bg-gray-800 text-teal-300 px-1 py-0.5 text-xs rounded"
           placeholder="filter"
         />
-        <button
-          onClick={() => setPaused((p) => !p)}
-          className="bg-gray-800 px-2 py-0.5 rounded"
-        >
-          {paused ? 'Resume' : 'Pause'}
-        </button>
-        <button onClick={onClear} className="bg-gray-800 px-2 py-0.5 rounded">
-          Clear
-        </button>
+        {onPauseToggle && (
+          <button
+            onClick={onPauseToggle}
+            className="bg-gray-800 px-2 py-0.5 rounded"
+          >
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+        )}
+        {onClear && (
+          <button onClick={onClear} className="bg-gray-800 px-2 py-0.5 rounded">
+            Clear
+          </button>
+        )}
       </div>
       <pre className="flex-1 overflow-y-auto whitespace-pre-wrap">
         {filtered.map((line, i) => (

--- a/desktop-app/src/components/PumpControls.jsx
+++ b/desktop-app/src/components/PumpControls.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+export default function PumpControls({ pump, onRun, onStop, onShowLogs }) {
+  const sectionTitle = {
+    fontSize: 13,
+    color: '#9aa4af',
+    textTransform: 'uppercase',
+    letterSpacing: '1.4px',
+    marginBottom: 6,
+  };
+
+  const btn = (active, danger = false) => ({
+    display: 'flex',
+    gap: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 44,
+    fontWeight: 700,
+    letterSpacing: '0.6px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    borderRadius: 6,
+    border: `2px solid ${danger ? '#e04f4f' : active ? '#2bd673' : '#848e9a'}`,
+    background: danger
+      ? 'linear-gradient(#341616, #2a1212)'
+      : active
+      ? 'linear-gradient(#193622, #112819)'
+      : 'linear-gradient(#171a1e, #14171a)',
+    color: danger ? '#ff8e8e' : active ? '#7fffb2' : '#d0d6dc',
+    boxShadow: active
+      ? '0 0 0 2px rgba(43,214,115,0.12) inset'
+      : '0 0 0 2px rgba(255,255,255,0.04) inset',
+  });
+
+  const lamp = (on, colorOn, colorOff = '#3a3f45') => ({
+    width: 12,
+    height: 12,
+    borderRadius: 12,
+    background: on ? colorOn : colorOff,
+    boxShadow: on ? `0 0 10px ${colorOn}` : 'none',
+    border: '1px solid #000',
+  });
+
+  return (
+    <div>
+      <div style={sectionTitle}>Pump Controls</div>
+      <div style={{ display: 'grid', gap: 10 }}>
+        <button style={btn(pump)} onClick={onRun} disabled={pump}>
+          <span style={lamp(pump, '#2bd673')} />
+          RUN P-101
+        </button>
+        <button style={btn(false, true)} onClick={onStop} disabled={!pump}>
+          <span style={lamp(!pump, '#e04f4f')} />
+          STOP P-101
+        </button>
+        <button
+          onClick={onShowLogs}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#9aa4af',
+            cursor: 'pointer',
+            fontSize: 13,
+            textAlign: 'left',
+            padding: 0,
+            marginTop: 4,
+          }}
+        >
+          Logs
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop-app/src/components/PumpLogsModal.jsx
+++ b/desktop-app/src/components/PumpLogsModal.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import LogViewer from './LogViewer';
+
+export default function PumpLogsModal({
+  isOpen,
+  onClose,
+  logs,
+  onClear,
+  paused,
+  onPauseToggle,
+  serviceActive,
+}) {
+  // close on escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const pillColor =
+    serviceActive === 'active'
+      ? 'bg-green-500/20 text-green-400'
+      : 'bg-red-500/20 text-red-400';
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-gray-900 text-teal-300 w-full max-w-3xl rounded shadow-lg flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-gray-700">
+          <div className="flex items-center gap-2 text-sm text-gray-400">
+            <span>Unit 400 &rsaquo; P-101 &rsaquo; Logs</span>
+            {serviceActive && (
+              <span className={`text-xs px-2 py-0.5 rounded ${pillColor}`}>
+                Service {serviceActive}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <button
+              onClick={onPauseToggle}
+              className="bg-gray-800 px-2 py-0.5 rounded"
+            >
+              {paused ? 'Resume' : 'Pause'}
+            </button>
+            <button onClick={onClear} className="bg-gray-800 px-2 py-0.5 rounded">
+              Clear
+            </button>
+          </div>
+        </div>
+        <div className="p-4 flex-1 overflow-hidden">
+          <LogViewer lines={logs} paused={paused} />
+        </div>
+        <div className="p-3 border-t border-gray-700 text-right">
+          <button onClick={onClose} className="bg-gray-800 px-3 py-1 rounded text-sm">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PumpLogsModal for viewing pump logs in a modal with service status
- centralize log state in dashboard and expose entry from pump controls
- enhance LogViewer with props, filtering, and external clear/pause hooks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: react-scripts: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b53a6e8fb8832bb10ebeda00b9a169