### PR TITLE
feat: robust websocket hook with connection UI

### DIFF
--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -1,11 +1,13 @@
 // DCSDashboard.jsx
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import SystemStatsCard from "./components/SystemStatsCard";
 import PumpControls from "./components/PumpControls";
 import PumpLogsModal from "./components/PumpLogsModal";
+import { useWsConnection } from "./hooks/useWsConnection";
+import ConnBadge from "./components/ConnBadge";
 
 /** ======== CONFIG ======== */
-const WS_URL = "ws://192.168.1.125:8765"; // <-- change if your Pi IP changes
+const PUMP_WS_URL = process.env.PUMP_WS_URL || "ws://192.168.1.125:8765"; // <-- change if your Pi IP changes
 const POLL_MS = 500;                       // simulation tick
 const LOW_LEVEL = 10;                      // % threshold for low-level alarm
 const CLEAR_LEVEL = LOW_LEVEL + 2;         // alarm considered cleared above this %
@@ -165,7 +167,6 @@ function TankGraphic({ levelPct }) {
 
 /** ======== MAIN PAGE ======== */
 export default function DCSDashboard() {
-  const [connOK, setConnOK] = useState(false);
   const [pump, setPump]   = useState(false);
 
   const [sys, setSys] = useState(null);
@@ -186,52 +187,13 @@ export default function DCSDashboard() {
   const [audioReady, setAudioReady] = useState(false);
   const audioRef = useRef(null);
 
-  // WS handling
-  const wsRef = useRef(null);
-  const reconnectRef = useRef(null);
-
-  /** ----- WebSocket connect + auto-reconnect ----- */
-  useEffect(() => {
-    let closed = false;
-    let backoff = 500;
-
-    const connect = () => {
-      if (closed) return;
-      const ws = new WebSocket(WS_URL);
-      wsRef.current = ws;
-
-      ws.onopen = () => {
-        setConnOK(true);
-        backoff = 500;
-      };
-
-      ws.onmessage = (ev) => {
-        try {
-          const msg = JSON.parse(ev.data);
-          if (msg.pump === "on") setPump(true);
-          if (msg.pump === "off") setPump(false);
-        } catch {/* ignore */}
-      };
-
-      ws.onclose = () => {
-        setConnOK(false);
-        if (!closed) {
-          clearTimeout(reconnectRef.current);
-          reconnectRef.current = setTimeout(connect, backoff);
-          backoff = Math.min(backoff * 2, 5000);
-        }
-      };
-
-      ws.onerror = () => ws.close();
-    };
-
-    connect();
-    return () => {
-      closed = true;
-      try { wsRef.current && wsRef.current.close(); } catch {}
-      clearTimeout(reconnectRef.current);
-    };
+  const handlePumpMessage = useCallback((msg) => {
+    if (msg.pump === "on") setPump(true);
+    if (msg.pump === "off") setPump(false);
   }, []);
+
+  const pumpConn = useWsConnection(PUMP_WS_URL, handlePumpMessage);
+  const connOK = pumpConn.state === "CONNECTED" || pumpConn.state === "DEGRADED";
 
   useEffect(() => {
     const wsStats = new WebSocket('ws://192.168.1.125:8770');
@@ -255,10 +217,7 @@ export default function DCSDashboard() {
 
   /** ----- Send command to Pi ----- */
   const sendPump = (on) => {
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ command: "pump", state: on ? "on" : "off", gpio: 17 }));
-    }
+    pumpConn.send({ command: "pump", state: on ? "on" : "off", gpio: 17 });
   };
 
   /** ----- Unlock audio (autoplay policy) ----- */
@@ -344,7 +303,7 @@ export default function DCSDashboard() {
           <div style={{ fontWeight: 800, letterSpacing: "1px" }}>
             UNIT 400 — TANK CONTROL
           </div>
-          <div style={statusPill(connOK)}>{connOK ? "CONNECTED" : "DISCONNECTED"}</div>
+          <ConnBadge state={pumpConn.state} latencyMs={pumpConn.latencyMs} />
           <div style={statusPill(pump)}>P-101 {pump ? "RUNNING" : "STOPPED"}</div>
         </div>
         <div style={{ color: "#9aa4af", fontSize: 13 }}>{datetime}</div>
@@ -362,10 +321,11 @@ export default function DCSDashboard() {
         <div>
           <div style={sectionTitle}>Connection</div>
           <div style={{ ...panelBase, display: "grid", gap: 8, fontSize: 13, color: "#c3cbd4" }}>
-            <div>WS URL: <span style={{ color: "#9aa4af" }}>{WS_URL}</span></div>
-            <div>Status: <span style={{ color: connOK ? "#7fffb2" : "#ff8e8e" }}>
-              {connOK ? "Online" : "Offline"}
-            </span></div>
+            <div>WS URL: <span style={{ color: "#9aa4af" }}>{PUMP_WS_URL}</span></div>
+            <div>Status: <ConnBadge state={pumpConn.state} latencyMs={pumpConn.latencyMs} /></div>
+            {(pumpConn.state === "NOT_CONFIGURED" || pumpConn.state === "OFFLINE" || pumpConn.state === "ERROR") && (
+              <button style={btn(false)} onClick={pumpConn.connect}>CONNECT</button>
+            )}
           </div>
         </div>
 

--- a/desktop-app/src/components/ConnBadge.jsx
+++ b/desktop-app/src/components/ConnBadge.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import TerminalLoadingBar from "./TerminalLoadingBar";
+
+const labels = {
+  NOT_CONFIGURED: "Not configured",
+  CONNECTING: "Connecting",
+  CONNECTED: "Connected",
+  DEGRADED: "Connected (no recent data)",
+  OFFLINE: "Offline",
+  ERROR: "Error",
+};
+
+const colors = {
+  NOT_CONFIGURED: "#848e9a",
+  CONNECTED: "#2d5",
+  DEGRADED: "#d9b300",
+  OFFLINE: "#e04f4f",
+  ERROR: "#e04f4f",
+};
+
+export default function ConnBadge({ state, latencyMs }) {
+  if (state === "CONNECTING") return <TerminalLoadingBar />;
+
+  const color = colors[state] || "#848e9a";
+  const label = labels[state] || state;
+  const showLatency =
+    latencyMs != null && (state === "CONNECTED" || state === "DEGRADED");
+
+  return (
+    <div
+      style={{
+        padding: "4px 10px",
+        borderRadius: 12,
+        border: `1px solid ${color}`,
+        color,
+        background: "rgba(255,255,255,0.05)",
+        fontSize: 13,
+      }}
+    >
+      {label}
+      {showLatency && ` ${latencyMs} ms`}
+    </div>
+  );
+}

--- a/desktop-app/src/components/TerminalLoadingBar.jsx
+++ b/desktop-app/src/components/TerminalLoadingBar.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+
+const frames = [
+  "[          ]",
+  "[==        ]",
+  "[====      ]",
+  "[======    ]",
+  "[========  ]",
+  "[==========]",
+];
+
+export default function TerminalLoadingBar() {
+  const [i, setI] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setI((v) => (v + 1) % frames.length), 250);
+    return () => clearInterval(t);
+  }, []);
+  return (
+    <span style={{ fontFamily: "Roboto Mono, Menlo, monospace" }}>
+      {frames[i]} connecting…
+    </span>
+  );
+}

--- a/desktop-app/src/hooks/useWsConnection.js
+++ b/desktop-app/src/hooks/useWsConnection.js
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const BACKOFF_STEPS = [1000, 2000, 4000, 8000, 16000, 30000];
+
+export function useWsConnection(url, onMessage) {
+  const [state, setState] = useState(url ? "CONNECTING" : "NOT_CONFIGURED");
+  const [readyState, setReadyState] = useState(WebSocket.CLOSED);
+  const [latencyMs, setLatencyMs] = useState(null);
+  const [lastMsgAt, setLastMsgAt] = useState(null);
+
+  const wsRef = useRef(null);
+  const hbRef = useRef(null);
+  const healthRef = useRef(null);
+  const reconnectRef = useRef(null);
+  const backoffRef = useRef(0);
+  const lastMsgRef = useRef(null);
+
+  const clearTimers = () => {
+    clearInterval(hbRef.current); hbRef.current = null;
+    clearInterval(healthRef.current); healthRef.current = null;
+    clearTimeout(reconnectRef.current); reconnectRef.current = null;
+  };
+
+  function scheduleReconnect() {
+    if (!url) return;
+    const delay = BACKOFF_STEPS[Math.min(backoffRef.current, BACKOFF_STEPS.length - 1)];
+    reconnectRef.current = setTimeout(() => {
+      backoffRef.current = Math.min(backoffRef.current + 1, BACKOFF_STEPS.length - 1);
+      doConnect();
+    }, delay);
+  }
+
+  function doConnect() {
+    if (!url) {
+      setState("NOT_CONFIGURED");
+      return;
+    }
+
+    clearTimers();
+    if (wsRef.current) {
+      try { wsRef.current.close(); } catch {}
+    }
+
+    setState("CONNECTING");
+    setReadyState(WebSocket.CONNECTING);
+
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+    lastMsgRef.current = Date.now();
+    setLastMsgAt(lastMsgRef.current);
+
+    ws.onopen = () => {
+      setState("CONNECTED");
+      setReadyState(ws.readyState);
+      backoffRef.current = 0;
+      clearInterval(hbRef.current);
+      hbRef.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          try { ws.send(JSON.stringify({ type: "ping", t: Date.now() })); } catch {}
+        }
+      }, 5000);
+    };
+
+    ws.onmessage = (ev) => {
+      lastMsgRef.current = Date.now();
+      setLastMsgAt(lastMsgRef.current);
+      let msg;
+      try { msg = JSON.parse(ev.data); } catch { msg = ev.data; }
+      if (msg && msg.type === "pong" && typeof msg.t === "number") {
+        setLatencyMs(Date.now() - msg.t);
+      } else if (msg !== undefined) {
+        onMessage && onMessage(msg);
+      }
+    };
+
+    ws.onclose = () => {
+      setReadyState(ws.readyState);
+      clearInterval(hbRef.current);
+      setState("OFFLINE");
+      scheduleReconnect();
+    };
+
+    ws.onerror = () => {
+      setReadyState(ws.readyState);
+      clearInterval(hbRef.current);
+      setState("ERROR");
+      try { ws.close(); } catch {}
+      scheduleReconnect();
+    };
+
+    clearInterval(healthRef.current);
+    healthRef.current = setInterval(() => {
+      const w = wsRef.current;
+      const rs = w ? w.readyState : WebSocket.CLOSED;
+      setReadyState(rs);
+      if (w && rs === WebSocket.OPEN) {
+        const diff = Date.now() - (lastMsgRef.current || 0);
+        if (diff > 10000) {
+          setState((s) => (s !== "DEGRADED" ? "DEGRADED" : s));
+        } else {
+          setState((s) => (s === "DEGRADED" ? "CONNECTED" : s));
+        }
+      } else {
+        setState((s) => {
+          if (s === "CONNECTING" || s === "NOT_CONFIGURED" || s === "ERROR") return s;
+          return "OFFLINE";
+        });
+      }
+    }, 1000);
+  }
+
+  const connect = useCallback(() => {
+    backoffRef.current = 0;
+    clearTimeout(reconnectRef.current);
+    doConnect();
+  }, [url]);
+
+  useEffect(() => {
+    if (url) {
+      connect();
+    } else {
+      setState("NOT_CONFIGURED");
+    }
+    return () => {
+      clearTimers();
+      if (wsRef.current) {
+        try { wsRef.current.close(); } catch {}
+        wsRef.current = null;
+      }
+    };
+  }, [url, connect]);
+
+  const send = useCallback((obj) => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(obj));
+      return true;
+    }
+    return false;
+  }, []);
+
+  return { state, readyState, latencyMs, lastMsgAt, connect, send };
+}

--- a/pi_server.py
+++ b/pi_server.py
@@ -117,6 +117,9 @@ async def handler(ws):
                 obj = json.loads(message)
             except json.JSONDecodeError:
                 continue
+            if obj.get("type") == "ping":
+                await ws.send(json.dumps({"type": "pong", "t": obj.get("t")}))
+                continue
             if obj.get("command") == "pump":
                 state = obj.get("state")
                 print(f"Pump command: {state}")


### PR DESCRIPTION
## Summary
- add reusable `useWsConnection` hook with heartbeat, backoff and metrics
- show connection status via `ConnBadge` and terminal-style loader
- respond to websocket pings on server for latency checks

## Testing
- `python -m py_compile pi_server.py`
- `npm test --prefix desktop-app` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b53f35f748832b87b5b990e666b844