### PR TITLE
Improve WebSocket reliability and log handling

### DIFF
--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -171,6 +171,7 @@ export default function DCSDashboard() {
 
   const [sys, setSys] = useState(null);
   const [logs, setLogs] = useState([]);
+  const pendingLogsRef = useRef([]);
   const [showPumpLogs, setShowPumpLogs] = useState(false);
   const [paused, setPaused] = useState(false);
   const [serviceActive, setServiceActive] = useState('inactive');
@@ -195,6 +196,10 @@ export default function DCSDashboard() {
   const pumpConn = useWsConnection(PUMP_WS_URL, handlePumpMessage);
   const connOK = pumpConn.state === "CONNECTED" || pumpConn.state === "DEGRADED";
 
+  const enqueueLogs = useCallback((lines) => {
+    pendingLogsRef.current.push(...lines);
+  }, []);
+
   useEffect(() => {
     const wsStats = new WebSocket('ws://192.168.1.125:8770');
 
@@ -205,14 +210,30 @@ export default function DCSDashboard() {
         if (msg.data && msg.data.service && typeof msg.data.service.active !== 'undefined') {
           setServiceActive(msg.data.service.active);
         }
+      } else if (msg.type === "log_batch") {
+        enqueueLogs(msg.lines);
+      } else if (msg.type === "log") {
+        enqueueLogs([msg.line]);
+      } else if (msg.type === "log_init") {
+        setLogs(msg.lines.slice(-200));
       }
-      if (msg.type === "log") setLogs(prev => [...prev, msg.line].slice(-200));
-      if (msg.type === "log_init") setLogs(msg.lines.slice(-200));
     };
 
     wsStats.onopen = () => console.log("Connected to stats/logs");
     wsStats.onclose = () => console.log("Disconnected from stats/logs");
     return () => wsStats.close();
+  }, [enqueueLogs]);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      if (pendingLogsRef.current.length) {
+        setLogs((prev) =>
+          [...prev, ...pendingLogsRef.current].slice(-500)
+        );
+        pendingLogsRef.current = [];
+      }
+    }, 150);
+    return () => clearInterval(t);
   }, []);
 
   /** ----- Send command to Pi ----- */

--- a/desktop-app/src/components/ConnBadge.jsx
+++ b/desktop-app/src/components/ConnBadge.jsx
@@ -5,7 +5,7 @@ const labels = {
   NOT_CONFIGURED: "Not configured",
   CONNECTING: "Connecting",
   CONNECTED: "Connected",
-  DEGRADED: "Connected (no recent data)",
+  DEGRADED: "Connected (no data >10s)",
   OFFLINE: "Offline",
   ERROR: "Error",
 };
@@ -23,8 +23,7 @@ export default function ConnBadge({ state, latencyMs }) {
 
   const color = colors[state] || "#848e9a";
   const label = labels[state] || state;
-  const showLatency =
-    latencyMs != null && (state === "CONNECTED" || state === "DEGRADED");
+  const showLatency = latencyMs != null && state === "CONNECTED";
 
   return (
     <div

--- a/desktop-app/src/components/LogViewer.jsx
+++ b/desktop-app/src/components/LogViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 /**
  * Generic log viewer with optional filtering and controls.
@@ -10,7 +10,7 @@ import React, { useEffect, useRef, useState } from 'react';
  *  - paused?: boolean           When true, auto-scroll is disabled
  *  - header?: string            Optional title to show in the header
  */
-export default function LogViewer({
+function LogViewer({
   lines,
   onClear,
   onPauseToggle,
@@ -25,10 +25,11 @@ export default function LogViewer({
     if (!paused) {
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [lines, paused, filter]);
+  }, [lines, paused]);
 
-  const filtered = lines.filter((l) =>
-    l.toLowerCase().includes(filter.toLowerCase())
+  const filtered = useMemo(
+    () => lines.filter((l) => l.toLowerCase().includes(filter.toLowerCase())),
+    [lines, filter]
   );
 
   return (
@@ -64,3 +65,5 @@ export default function LogViewer({
     </div>
   );
 }
+
+export default React.memo(LogViewer);

--- a/desktop-app/src/components/TerminalLoadingBar.jsx
+++ b/desktop-app/src/components/TerminalLoadingBar.jsx
@@ -1,23 +1,34 @@
 import React, { useEffect, useState } from "react";
 
 const frames = [
-  "[          ]",
-  "[==        ]",
-  "[====      ]",
-  "[======    ]",
-  "[========  ]",
-  "[==========]",
+  "[>         ]",
+  "[=>        ]",
+  "[==>       ]",
+  "[===>      ]",
+  "[====>     ]",
+  "[=====>    ]",
+  "[======>   ]",
+  "[=======>  ]",
+  "[========> ]",
+  "[=========>]",
 ];
 
 export default function TerminalLoadingBar() {
   const [i, setI] = useState(0);
+
   useEffect(() => {
-    const t = setInterval(() => setI((v) => (v + 1) % frames.length), 250);
+    const t = setInterval(() => setI((v) => (v + 1) % frames.length), 150);
     return () => clearInterval(t);
   }, []);
+
   return (
-    <span style={{ fontFamily: "Roboto Mono, Menlo, monospace" }}>
-      {frames[i]} connecting…
+    <span
+      role="status"
+      aria-live="polite"
+      style={{ fontFamily: "monospace", whiteSpace: "pre" }}
+    >
+      <span style={{ display: "inline-block", width: "14ch" }}>{frames[i]}</span>
+      connecting…
     </span>
   );
 }

--- a/desktop-app/src/hooks/useWsConnection.js
+++ b/desktop-app/src/hooks/useWsConnection.js
@@ -13,47 +13,71 @@ export function useWsConnection(url, onMessage) {
   const healthRef = useRef(null);
   const reconnectRef = useRef(null);
   const backoffRef = useRef(0);
+  const missedBeatsRef = useRef(0);
+  const firstMsgRef = useRef(false);
   const lastMsgRef = useRef(null);
+  const onMsgRef = useRef(onMessage);
+  const msgQueueRef = useRef([]);
+  const rafRef = useRef(null);
+
+  useEffect(() => {
+    onMsgRef.current = onMessage;
+  }, [onMessage]);
 
   const clearTimers = () => {
     clearInterval(hbRef.current); hbRef.current = null;
     clearInterval(healthRef.current); healthRef.current = null;
     clearTimeout(reconnectRef.current); reconnectRef.current = null;
+    if (rafRef.current) cancelAnimationFrame(rafRef.current); rafRef.current = null;
   };
 
-  function scheduleReconnect() {
+  const scheduleReconnect = () => {
     if (!url) return;
-    const delay = BACKOFF_STEPS[Math.min(backoffRef.current, BACKOFF_STEPS.length - 1)];
+    const base = BACKOFF_STEPS[Math.min(backoffRef.current, BACKOFF_STEPS.length - 1)];
+    const jitter = base * (Math.random() * 0.4 - 0.2);
     reconnectRef.current = setTimeout(() => {
       backoffRef.current = Math.min(backoffRef.current + 1, BACKOFF_STEPS.length - 1);
       doConnect();
-    }, delay);
-  }
+    }, base + jitter);
+  };
 
-  function doConnect() {
+  const flushQueue = () => {
+    rafRef.current = null;
+    const queue = msgQueueRef.current;
+    msgQueueRef.current = [];
+    queue.forEach((msg) => {
+      if (msg && msg.type === "pong" && typeof msg.t === "number") {
+        setLatencyMs(Date.now() - msg.t);
+      } else if (msg !== undefined) {
+        onMsgRef.current && onMsgRef.current(msg);
+      }
+    });
+  };
+
+  const doConnect = () => {
     if (!url) {
       setState("NOT_CONFIGURED");
       return;
     }
 
-    clearTimers();
-    if (wsRef.current) {
-      try { wsRef.current.close(); } catch {}
+    const existing = wsRef.current;
+    if (existing && (existing.readyState === WebSocket.OPEN || existing.readyState === WebSocket.CONNECTING)) {
+      return; // already connected or connecting
     }
 
+    clearTimers();
     setState("CONNECTING");
     setReadyState(WebSocket.CONNECTING);
 
     const ws = new WebSocket(url);
     wsRef.current = ws;
+    firstMsgRef.current = false;
+    missedBeatsRef.current = 0;
     lastMsgRef.current = Date.now();
     setLastMsgAt(lastMsgRef.current);
 
     ws.onopen = () => {
-      setState("CONNECTED");
       setReadyState(ws.readyState);
-      backoffRef.current = 0;
-      clearInterval(hbRef.current);
       hbRef.current = setInterval(() => {
         if (ws.readyState === WebSocket.OPEN) {
           try { ws.send(JSON.stringify({ type: "ping", t: Date.now() })); } catch {}
@@ -64,31 +88,33 @@ export function useWsConnection(url, onMessage) {
     ws.onmessage = (ev) => {
       lastMsgRef.current = Date.now();
       setLastMsgAt(lastMsgRef.current);
+      missedBeatsRef.current = 0;
+      if (!firstMsgRef.current) {
+        backoffRef.current = 0;
+        firstMsgRef.current = true;
+        setState("CONNECTED");
+      }
       let msg;
       try { msg = JSON.parse(ev.data); } catch { msg = ev.data; }
-      if (msg && msg.type === "pong" && typeof msg.t === "number") {
-        setLatencyMs(Date.now() - msg.t);
-      } else if (msg !== undefined) {
-        onMessage && onMessage(msg);
+      msgQueueRef.current.push(msg);
+      if (!rafRef.current) {
+        rafRef.current = requestAnimationFrame(flushQueue);
       }
     };
 
     ws.onclose = () => {
       setReadyState(ws.readyState);
-      clearInterval(hbRef.current);
       setState("OFFLINE");
       scheduleReconnect();
     };
 
     ws.onerror = () => {
       setReadyState(ws.readyState);
-      clearInterval(hbRef.current);
       setState("ERROR");
       try { ws.close(); } catch {}
       scheduleReconnect();
     };
 
-    clearInterval(healthRef.current);
     healthRef.current = setInterval(() => {
       const w = wsRef.current;
       const rs = w ? w.readyState : WebSocket.CLOSED;
@@ -96,18 +122,25 @@ export function useWsConnection(url, onMessage) {
       if (w && rs === WebSocket.OPEN) {
         const diff = Date.now() - (lastMsgRef.current || 0);
         if (diff > 10000) {
-          setState((s) => (s !== "DEGRADED" ? "DEGRADED" : s));
+          const beats = Math.floor(diff / 10000);
+          missedBeatsRef.current = beats;
+          if (beats >= 2) {
+            setState("OFFLINE");
+            try { w.close(); } catch {}
+          } else {
+            setState("DEGRADED");
+          }
         } else {
+          missedBeatsRef.current = 0;
           setState((s) => (s === "DEGRADED" ? "CONNECTED" : s));
         }
       } else {
-        setState((s) => {
-          if (s === "CONNECTING" || s === "NOT_CONFIGURED" || s === "ERROR") return s;
-          return "OFFLINE";
-        });
+        setState((s) => (
+          s === "CONNECTING" || s === "NOT_CONFIGURED" || s === "ERROR" ? s : "OFFLINE"
+        ));
       }
     }, 1000);
-  }
+  };
 
   const connect = useCallback(() => {
     backoffRef.current = 0;
@@ -141,3 +174,4 @@ export function useWsConnection(url, onMessage) {
 
   return { state, readyState, latencyMs, lastMsgAt, connect, send };
 }
+

--- a/pi_server.py
+++ b/pi_server.py
@@ -7,7 +7,7 @@ import psutil
 import websockets
 
 CONNECTED = set()
-LOG_BUFFER = deque(maxlen=100)
+LOG_BUFFER = deque(maxlen=200)
 
 
 async def get_cpu_temp():
@@ -53,7 +53,9 @@ async def gather_metrics():
 
 async def send_all(message: str):
     if CONNECTED:
-        await asyncio.gather(*[ws.send(message) for ws in list(CONNECTED)])
+        await asyncio.gather(
+            *[ws.send(message) for ws in list(CONNECTED)], return_exceptions=True
+        )
 
 
 async def metrics_publisher():
@@ -77,7 +79,7 @@ async def init_log_buffer():
         "-u",
         "tankpi.service",
         "-n",
-        "100",
+        "200",
         "-o",
         "short-iso",
     ]
@@ -91,17 +93,40 @@ async def init_log_buffer():
 
 async def follow_journal():
     cmd = ["journalctl", "-u", "tankpi.service", "-f", "-o", "short-iso"]
-    proc = await asyncio.create_subprocess_exec(
-        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-    )
     while True:
-        line = await proc.stdout.readline()
-        if not line:
-            await asyncio.sleep(0.1)
-            continue
-        text = line.decode().rstrip()
-        LOG_BUFFER.append(text)
-        await send_all(json.dumps({"type": "log", "line": text}))
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        batch = []
+        flush_task = None
+
+        async def flush():
+            nonlocal batch, flush_task
+            if batch:
+                await send_all(json.dumps({"type": "log_batch", "lines": batch}))
+                batch = []
+            flush_task = None
+
+        try:
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                text = line.decode().rstrip()
+                LOG_BUFFER.append(text)
+                batch.append(text)
+                if flush_task is None:
+                    flush_task = asyncio.create_task(asyncio.sleep(0.15))
+                    flush_task.add_done_callback(lambda t: asyncio.create_task(flush()))
+        finally:
+            if flush_task is not None:
+                await flush()
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+        await asyncio.sleep(1)
 
 
 async def handler(ws):
@@ -110,7 +135,7 @@ async def handler(ws):
         # send initial metrics and logs
         data = await gather_metrics()
         await ws.send(json.dumps({"type": "metrics", "data": data}))
-        await ws.send(json.dumps({"type": "log_init", "lines": list(LOG_BUFFER)}))
+        await ws.send(json.dumps({"type": "log_init", "lines": list(LOG_BUFFER)[-200:]}))
 
         async for message in ws:
             try:


### PR DESCRIPTION
## Summary
- add heartbeat, jittered reconnects, and missed-beat detection to WebSocket hook
- replace loading indicator with fixed-width terminal-style bar and update connection badge
- batch and memoize log handling on client and server to prevent freezes

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m py_compile pi_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b545e13da8832b819d6a22d74cddce