### PR TITLE
Handle WebSocket reconnection and show device status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -13,19 +13,42 @@ function Dashboard() {
     flow: 0,
     pumpStatus: false
   });
+  const [isConnected, setIsConnected] = useState(false);
 
   const tapHeightPercent = 20;
   const visualMinFill = 8;
 
   useEffect(() => {
-    const ws = new WebSocket('ws://192.168.1.125:8765');
-    ws.onopen = () => console.log("Connected to Raspberry Pi simulator");
-    ws.onmessage = (event) => {
-      const temp = parseInt(event.data);
-      setData(prev => ({ ...prev, temperature: temp }));
+    let ws;
+    let reconnectTimer;
+
+    const connect = () => {
+      ws = new WebSocket('ws://192.168.1.125:8765');
+      ws.onopen = () => {
+        console.log('Connected to Raspberry Pi simulator');
+        setIsConnected(true);
+      };
+      ws.onmessage = (event) => {
+        const temp = parseInt(event.data);
+        setData(prev => ({ ...prev, temperature: temp }));
+      };
+      ws.onclose = () => {
+        console.log('Disconnected from simulator');
+        setIsConnected(false);
+        reconnectTimer = setTimeout(connect, 3000);
+      };
+      ws.onerror = () => {
+        setIsConnected(false);
+        ws.close();
+      };
     };
-    ws.onclose = () => console.log("Disconnected from simulator");
-    return () => ws.close();
+
+    connect();
+
+    return () => {
+      clearTimeout(reconnectTimer);
+      if (ws) ws.close();
+    };
   }, []);
 
   useEffect(() => {
@@ -67,7 +90,12 @@ function Dashboard() {
 
   return (
     <div style={containerStyle}>
-      <Navbar temperature={35} humidity={62} site="Unit 400 Tank Control" />
+      <Navbar
+        temperature={35}
+        humidity={62}
+        site="Unit 400 Tank Control"
+        connected={isConnected}
+      />
       <PumpButton pumpStatus={data.pumpStatus} togglePump={togglePump} />
 
       <svg width="1300" height="700" style={{ backgroundColor: '#000', borderRadius: '8px' }}>

--- a/desktop-app/src/components/Navbar.js
+++ b/desktop-app/src/components/Navbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function Navbar({ temperature, humidity, site }) {
+function Navbar({ temperature, humidity, site, connected }) {
   const navbarStyle = {
     width: '100%',
     backgroundColor: '#1c1c1e',
@@ -42,6 +42,7 @@ function Navbar({ temperature, humidity, site }) {
     <div style={navbarStyle}>
       <div style={{ fontSize: '16px' }}>{site || "Plant Monitoring Dashboard"}</div>
       <div style={rightSideStyle}>
+        <div><span style={iconStyle}>{connected ? '🟢' : '🔴'}</span>{connected ? 'Online' : 'Offline'}</div>
         <div><span style={iconStyle}>🌡</span>{temperature}°C</div>
         <div><span style={iconStyle}>💧</span>{humidity}% RH</div>
         <div><span style={iconStyle}>🕒</span>{currentTime}</div>


### PR DESCRIPTION
## Summary
- Automatically reconnect to Raspberry Pi WebSocket and track connection state
- Display device online/offline status in the Navbar
- Ignore node_modules directories in git

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b556390a50832bb04c652c52228b07