### PR TITLE
feat: improve websocket reconnection

### DIFF
--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -4,12 +4,11 @@ import SystemStatsCard from "./components/SystemStatsCard";
 import PumpControls from "./components/PumpControls";
 import PumpLogsModal from "./components/PumpLogsModal";
 import ConnBadge from "./components/ConnBadge";
-import { autoWS } from "./utils/autoWS";
+import { useDcsConnections } from "./hooks/useDcsConnections";
 
 /** ======== CONFIG ======== */
 const HOST = process.env.REACT_APP_PI_HOST || window.location.hostname;
 const RELAY_WS = `ws://${HOST}:${process.env.REACT_APP_RELAY_PORT || 8765}`;
-const STATS_WS = `ws://${HOST}:${process.env.REACT_APP_STATS_PORT || 8770}`;
 const POLL_MS = 500;                       // simulation tick
 const LOW_LEVEL = 10;                      // % threshold for low-level alarm
 const CLEAR_LEVEL = LOW_LEVEL + 2;         // alarm considered cleared above this %
@@ -185,8 +184,57 @@ export default function DCSDashboard() {
   const [showPumpLogs, setShowPumpLogs] = useState(false);
   const [paused, setPaused] = useState(false);
 
-  const relayWsRef = useRef(null);
-  const [relayState, setRelayState] = useState("CONNECTING");
+  const handleRelayRaw = useCallback(
+    (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      handlePumpMessage(msg);
+    },
+    [handlePumpMessage]
+  );
+
+  const handleStatsRaw = useCallback(
+    (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        if (msg.type === "metrics" && msg.data) {
+          const d = msg.data;
+          setStats((s) => ({
+            ...s,
+            connected: true,
+            cpu_pct: d.cpu_pct ?? s.cpu_pct,
+            cpu_temp_c: d.cpu_temp_c ?? s.cpu_temp_c,
+            mem_pct: d.mem_pct ?? s.mem_pct,
+            disk_root_pct: d.disk_root_pct ?? s.disk_root_pct,
+            uptime_s: d.uptime_s ?? s.uptime_s,
+            service: d.service ?? s.service,
+          }));
+        } else if (msg.type === "log_batch") {
+          enqueueLogs(msg.lines);
+        } else if (msg.type === "log") {
+          enqueueLogs([msg.line]);
+        } else if (msg.type === "log_init") {
+          setLogs(msg.lines.slice(-200));
+        }
+      } catch {}
+    },
+    [enqueueLogs]
+  );
+
+  const {
+    relayConnected,
+    connecting,
+    sendRelay,
+  } = useDcsConnections({
+    onRelayMessage: handleRelayRaw,
+    onStatsMessage: handleStatsRaw,
+  });
+
+  const relayState = relayConnected ? "CONNECTED" : connecting ? "CONNECTING" : "OFFLINE";
   const connOK = relayState === "CONNECTED";
 
   // PVs
@@ -210,71 +258,7 @@ export default function DCSDashboard() {
     pendingLogsRef.current.push(...lines);
   }, []);
 
-  useEffect(() => {
-    setRelayState("CONNECTING");
-
-    const stopRelay = autoWS(RELAY_WS, {
-      onOpen: (e) => {
-        relayWsRef.current = e.target;
-        setRelayState("CONNECTED");
-      },
-      onClose: () => {
-        relayWsRef.current = null;
-        setRelayState("OFFLINE");
-      },
-      onMessage: (e) => {
-        let msg;
-        try {
-          msg = JSON.parse(e.data);
-        } catch {
-          return;
-        }
-        handlePumpMessage(msg);
-      },
-    });
-
-    const stopStats = autoWS(STATS_WS, {
-      onOpen: () => setStats((s) => ({ ...s, connected: true })),
-      onClose: () => setStats((s) => ({ ...s, connected: false })),
-      onMessage: (e) => {
-        try {
-          const msg = JSON.parse(e.data);
-          if (msg.type === "metrics" && msg.data) {
-            const d = msg.data;
-            setStats((s) => ({
-              ...s,
-              connected: true,
-              cpu_pct: d.cpu_pct ?? s.cpu_pct,
-              cpu_temp_c: d.cpu_temp_c ?? s.cpu_temp_c,
-              mem_pct: d.mem_pct ?? s.mem_pct,
-              disk_root_pct: d.disk_root_pct ?? s.disk_root_pct,
-              uptime_s: d.uptime_s ?? s.uptime_s,
-              service: d.service ?? s.service,
-            }));
-          } else if (msg.type === "log_batch") {
-            enqueueLogs(msg.lines);
-          } else if (msg.type === "log") {
-            enqueueLogs([msg.line]);
-          } else if (msg.type === "log_init") {
-            setLogs(msg.lines.slice(-200));
-          }
-        } catch {}
-      },
-    });
-
-    const onVis = () => {
-      if (document.visibilityState === "visible") {
-        // autoWS will handle reconnects; placeholder for future logic
-      }
-    };
-    document.addEventListener("visibilitychange", onVis);
-
-    return () => {
-      stopRelay();
-      stopStats();
-      document.removeEventListener("visibilitychange", onVis);
-    };
-  }, [enqueueLogs, handlePumpMessage]);
+  // remove old autoWS effect; connections handled by useDcsConnections
 
   useEffect(() => {
     const t = setInterval(() => {
@@ -290,12 +274,9 @@ export default function DCSDashboard() {
 
   /** ----- Send command to Pi ----- */
   const sendPump = (on) => {
-    const ws = relayWsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(
-        JSON.stringify({ command: "pump", state: on ? "on" : "off", gpio: 17 })
-      );
-    }
+    sendRelay(
+      JSON.stringify({ command: "pump", state: on ? "on" : "off", gpio: 17 })
+    );
   };
 
   /** ----- Unlock audio (autoplay policy) ----- */

--- a/desktop-app/src/hooks/useDcsConnections.js
+++ b/desktop-app/src/hooks/useDcsConnections.js
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+import { spawnAutoWS } from "../utils/autoWS";
+
+const HOST = process.env.REACT_APP_PI_HOST || window.location.hostname;
+const RELAY_WS = `ws://${HOST}:${process.env.REACT_APP_RELAY_PORT || 8765}`;
+const STATS_WS = `ws://${HOST}:${process.env.REACT_APP_STATS_PORT || 8770}`;
+
+export function useDcsConnections({ onRelayMessage, onStatsMessage } = {}) {
+  const [relayConnected, setRelayConnected] = useState(false);
+  const [statsConnected, setStatsConnected] = useState(false);
+  const [connecting, setConnecting] = useState(true);
+  const [retryInMs, setRetryInMs] = useState(0);
+  const [statusText, setStatusText] = useState("connecting…");
+  const [lastError, setLastError] = useState(null);
+
+  const relayRef = useRef(null);
+  const statsRef = useRef(null);
+
+  const updateStatus = () => {
+    const both = relayConnected && statsConnected;
+    if (both) {
+      setConnecting(false);
+      setStatusText("connected");
+      setRetryInMs(0);
+    } else if (retryInMs > 0) {
+      setConnecting(true);
+      setStatusText(`waiting ${(retryInMs / 1000).toFixed(1)}s to retry…`);
+    } else {
+      setConnecting(true);
+      setStatusText("connecting…");
+    }
+  };
+
+  useEffect(updateStatus, [relayConnected, statsConnected, retryInMs]);
+
+  // countdown for retryInMs
+  useEffect(() => {
+    if (retryInMs > 0) {
+      const t = setInterval(() => {
+        setRetryInMs((ms) => (ms > 200 ? ms - 200 : 0));
+      }, 200);
+      return () => clearInterval(t);
+    }
+  }, [retryInMs]);
+
+  useEffect(() => {
+    const updateRetry = (ms) => {
+      setRetryInMs((prev) => (prev === 0 ? ms : Math.min(prev, ms)));
+    };
+
+    relayRef.current = spawnAutoWS(
+      RELAY_WS,
+      {
+        onOpen: () => setRelayConnected(true),
+        onClose: () => setRelayConnected(false),
+        onError: (e) => setLastError((e && e.message) || "relay error"),
+        onMessage: (e) => onRelayMessage?.(e.data),
+      },
+      { onPlannedRetry: updateRetry }
+    );
+
+    statsRef.current = spawnAutoWS(
+      STATS_WS,
+      {
+        onOpen: () => setStatsConnected(true),
+        onClose: () => setStatsConnected(false),
+        onError: (e) => setLastError((e && e.message) || "stats error"),
+        onMessage: (e) => onStatsMessage?.(e.data),
+      },
+      { onPlannedRetry: updateRetry }
+    );
+
+    relayRef.current.start();
+    statsRef.current.start();
+
+    const vis = () => {
+      if (
+        document.visibilityState === "visible" &&
+        !(relayConnected && statsConnected)
+      ) {
+        relayRef.current?.poke();
+        statsRef.current?.poke();
+      }
+    };
+    document.addEventListener("visibilitychange", vis);
+
+    return () => {
+      document.removeEventListener("visibilitychange", vis);
+      relayRef.current?.stop();
+      statsRef.current?.stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const connectNow = () => {
+    setStatusText("connecting…");
+    setRetryInMs(0);
+    relayRef.current?.poke();
+    statsRef.current?.poke();
+  };
+
+  const sendRelay = (data) => relayRef.current?.send(data);
+
+  return {
+    connected: relayConnected && statsConnected,
+    relayConnected,
+    statsConnected,
+    connecting,
+    retryInMs,
+    statusText,
+    lastError,
+    connectNow,
+    sendRelay,
+  };
+}

--- a/desktop-app/src/utils/autoWS.js
+++ b/desktop-app/src/utils/autoWS.js
@@ -1,15 +1,36 @@
-export function autoWS(url, { onOpen, onMessage, onClose, onError } = {}) {
-  let ws;
-  let backoff = 500; // ms
-  const max = 8000;
+// Minimal reconnecting WebSocket with backoff + jitter.
+// Internal helper; do not export to UI.
+export function spawnAutoWS(url, handlers = {}, opts = {}) {
+  const { onOpen, onMessage, onClose, onError } = handlers;
+  const {
+    initialDelay = 500,
+    maxDelay = 8000,
+    jitterRatio = 0.1,
+    onPlannedRetry,
+  } = opts;
+
+  let ws = null;
   let stopped = false;
+  let delay = initialDelay;
+  let timer = null;
+
+  const jitter = (ms) => {
+    const j = ms * jitterRatio;
+    return ms + (Math.random() * 2 * j - j); // ±10%
+  };
 
   const connect = () => {
     if (stopped) return;
-    ws = new WebSocket(url);
+    try {
+      ws = new WebSocket(url);
+    } catch (e) {
+      onError?.(e);
+      scheduleReconnect();
+      return;
+    }
 
     ws.onopen = (ev) => {
-      backoff = 500;
+      delay = initialDelay;
       onOpen?.(ev);
     };
 
@@ -17,9 +38,7 @@ export function autoWS(url, { onOpen, onMessage, onClose, onError } = {}) {
 
     ws.onclose = (ev) => {
       onClose?.(ev);
-      if (stopped) return;
-      setTimeout(connect, backoff);
-      backoff = Math.min(backoff * 2, max);
+      scheduleReconnect();
     };
 
     ws.onerror = (ev) => {
@@ -28,10 +47,35 @@ export function autoWS(url, { onOpen, onMessage, onClose, onError } = {}) {
     };
   };
 
-  connect();
+  const scheduleReconnect = () => {
+    if (stopped) return;
+    const wait = Math.round(jitter(delay));
+    timer = setTimeout(connect, wait);
+    delay = Math.min(delay * 2, maxDelay);
+    onPlannedRetry?.(wait);
+  };
 
-  return () => {
+  const start = () => { connect(); };
+  const stop = () => {
     stopped = true;
+    if (timer) clearTimeout(timer);
     try { ws && ws.close(); } catch {}
   };
+  const poke = () => {
+    if (timer) clearTimeout(timer);
+    delay = initialDelay;
+    try { ws && ws.close(); } catch {}
+    timer = setTimeout(connect, 0);
+  };
+  const send = (data) => {
+    try {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(data);
+        return true;
+      }
+    } catch {}
+    return false;
+  };
+
+  return { start, stop, poke, send };
 }


### PR DESCRIPTION
## Summary
- add reusable auto-reconnecting WebSocket with jittered exponential backoff
- centralize relay and stats handling in `useDcsConnections`
- wire dashboard to shared connection manager and retain pump messaging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5e890d454832b8630dceae3697ee7