### PR TITLE
Improve log update responsiveness

### DIFF
--- a/desktop-app/src/Dashboard.js
+++ b/desktop-app/src/Dashboard.js
@@ -181,12 +181,26 @@ export default function DCSDashboard() {
   });
   const [logs, setLogs] = useState([]);
   const pendingLogsRef = useRef([]);
+  const flushHandleRef = useRef(null);
   const [showPumpLogs, setShowPumpLogs] = useState(false);
   const [paused, setPaused] = useState(false);
 
+  const flushPendingLogs = useCallback(() => {
+    if (pendingLogsRef.current.length) {
+      setLogs((prev) =>
+        [...prev, ...pendingLogsRef.current].slice(-500)
+      );
+      pendingLogsRef.current = [];
+    }
+    flushHandleRef.current = null;
+  }, []);
+
   const enqueueLogs = useCallback((lines) => {
     pendingLogsRef.current.push(...lines);
-  }, []);
+    if (flushHandleRef.current === null) {
+      flushHandleRef.current = requestAnimationFrame(flushPendingLogs);
+    }
+  }, [flushPendingLogs]);
 
   const handlePumpMessage = useCallback((raw) => {
     try {
@@ -260,15 +274,11 @@ export default function DCSDashboard() {
   // remove old autoWS effect; connections handled by useDcsConnections
 
   useEffect(() => {
-    const t = setInterval(() => {
-      if (pendingLogsRef.current.length) {
-        setLogs((prev) =>
-          [...prev, ...pendingLogsRef.current].slice(-500)
-        );
-        pendingLogsRef.current = [];
+    return () => {
+      if (flushHandleRef.current !== null) {
+        cancelAnimationFrame(flushHandleRef.current);
       }
-    }, 150);
-    return () => clearInterval(t);
+    };
   }, []);
 
   /** ----- Send command to Pi ----- */

--- a/pi_server.py
+++ b/pi_server.py
@@ -43,7 +43,7 @@ import websockets
 PORT = 8770
 SERVICE = "tankpi.service"
 LOG_MAX = 200
-LOG_BATCH_MS = 150
+LOG_BATCH_MS = 50
 METRICS_PERIOD = 5
 
 # ---- State ----


### PR DESCRIPTION
## Summary
- Reduce log batching delay in Pi server for faster broadcasts
- Use animation frame flush in dashboard for smoother log updates

## Testing
- `python -m py_compile pi_server.py`
- `python -m py_compile desktop-app/raspberry-pi/pi_server.py`
- `npm test -- --watchAll=false` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5f68fa498832b926a6b772c71a0b5